### PR TITLE
Addition of Table fields for big query

### DIFF
--- a/BigQuery_Table_Fields.txt
+++ b/BigQuery_Table_Fields.txt
@@ -1,0 +1,1 @@
+sensorID:STRING,timecollected:TIMESTAMP,zipcode:INTEGER,latitude:FLOAT,longitude:FLOAT,temperature:FLOAT,humidity:FLOAT,dewpoint:FLOAT,pressure:FLOAT


### PR DESCRIPTION
When creating the BigQuery table, we have the opportunity to enter the fields as a text string.  This commit adds a file which contains the required text.